### PR TITLE
Add noreturn show in function signature

### DIFF
--- a/test/db/extras/ghidra
+++ b/test/db/extras/ghidra
@@ -3117,3 +3117,27 @@ undefined8 main(void)
 }
 EOF
 RUN
+
+
+NAME=show noreturn
+FILE=rizin-testbins/elf/ioli/crackme0x07
+CMDS=<<EOF
+aaa
+s sym.imp.exit
+pdg
+EOF
+EXPECT=<<EOF
+
+// WARNING: Switch with 1 destination removed at 0x080483e8
+// WARNING: [rz-ghidra] Failed to match type signed int for variable var_ch to Decompiler type: Unknown type identifier
+// signed
+// WARNING: [rz-ghidra] Detected overlap for variable var_dh
+
+void sym.imp.exit noreturn (void)
+{
+    // WARNING: Treating indirect jump as call
+    (**(code **)0x8049ffc)(0x30);
+    return;
+}
+EOF
+RUN


### PR DESCRIPTION
**Detailed description**
Show noreturn attribute  for no return function
now the expected output like this:
```c
void sym.imp.exit noreturn (void)
{
    // WARNING: Treating indirect jump as call
    (*_reloc.dyld_stub_binder)();
    returndebug in rz_core_annotated_code_print;
}
```
**Test plan:**
seek to a noreturn function and `pdg` to see.


**Closing issue:**
closes #86 

**Testbin**
[rr.zip](https://github.com/radareorg/r2ghidra-dec/files/3670319/rr.zip)
